### PR TITLE
Beheben von offenen SQL Connections und Not Acknowledged

### DIFF
--- a/client/src/main/java/com/example/client/ZahlungsProducer.java
+++ b/client/src/main/java/com/example/client/ZahlungsProducer.java
@@ -28,15 +28,11 @@ public class ZahlungsProducer implements AutoCloseable {
     factory.setUsername(dotenv.get("RABBITMQ_USERNAME"));
     factory.setPassword(dotenv.get("RABBITMQ_PASSWORD"));
 
-    factory.setThreadFactory(Thread.ofVirtual().factory());
-
     this.connection = factory.newConnection();
   }
 
   public void sendeZahlungsauftrag(Zahlungsauftrag auftrag) {
     try (var channel = connection.createChannel()) {
-      channel.queueDeclare(queueName, true, false, false, null);
-
       byte[] body = MAPPER.writeValueAsBytes(auftrag);
       channel.basicPublish("", queueName, null, body);
 

--- a/grpc/src/main/java/com/example/grpc/GrpcServer.java
+++ b/grpc/src/main/java/com/example/grpc/GrpcServer.java
@@ -27,7 +27,21 @@ public class GrpcServer {
     server.start();
     logger.info("gRPC-Server gestartet auf Port {}", PORT);
 
-    Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown));
+    Runtime.getRuntime()
+        .addShutdownHook(
+            Thread.ofVirtual()
+                .unstarted(
+                    () -> {
+                      logger.info("gRPC-Server wird heruntergefahren...");
+                      server.shutdown();
+                      try {
+                        server.awaitTermination();
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                      }
+                      logger.info("Schließe Datenbankverbindungspool...");
+                      com.example.grpc.config.DatabaseConfig.shutdown();
+                    }));
 
     server.awaitTermination();
   }

--- a/grpc/src/main/java/com/example/grpc/config/DatabaseConfig.java
+++ b/grpc/src/main/java/com/example/grpc/config/DatabaseConfig.java
@@ -16,11 +16,18 @@ public class DatabaseConfig {
     config.setUsername(dotenv.get("GRPC_DB_USERNAME"));
     config.setPassword(dotenv.get("GRPC_DB_PASSWORD"));
     config.setMaximumPoolSize(10);
+    config.setLeakDetectionThreshold(10_000);
 
     dataSource = new HikariDataSource(config);
   }
 
   public static DataSource getInstance() {
     return dataSource;
+  }
+
+  public static void shutdown() {
+    if (dataSource != null && !dataSource.isClosed()) {
+      dataSource.close();
+    }
   }
 }

--- a/grpc/src/main/java/com/example/grpc/repository/RechnungspositionRepository.java
+++ b/grpc/src/main/java/com/example/grpc/repository/RechnungspositionRepository.java
@@ -6,9 +6,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
-import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /// Repository für Rechnungspositionen.
 public class RechnungspositionRepository {
@@ -20,13 +17,7 @@ public class RechnungspositionRepository {
       ) VALUES (?, ?, ?, ?, ?)
       """;
 
-  private static final Logger logger = LoggerFactory.getLogger(RechnungspositionRepository.class);
-
-  private final DataSource dataSource;
-
-  public RechnungspositionRepository(final DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  public RechnungspositionRepository() {}
 
   /// Speichert Rechnungspositionen.
   ///
@@ -38,14 +29,9 @@ public class RechnungspositionRepository {
       final Connection conn, final List<Rechnungsposition> positionen, final UUID rechnungsId)
       throws SQLException {
     try (PreparedStatement stmt = conn.prepareStatement(INSERT_POSITION_SQL)) {
-      positionen.forEach(
-          position -> {
-            try {
-              insertPosition(stmt, rechnungsId, position);
-            } catch (SQLException e) {
-              throw new RuntimeException(e);
-            }
-          });
+      for (final Rechnungsposition position : positionen) {
+        insertPosition(stmt, rechnungsId, position);
+      }
       stmt.executeBatch();
     }
   }

--- a/grpc/src/main/java/com/example/grpc/service/RechnungsmetadatenService.java
+++ b/grpc/src/main/java/com/example/grpc/service/RechnungsmetadatenService.java
@@ -27,7 +27,7 @@ public class RechnungsmetadatenService
   public RechnungsmetadatenService() {
     this.dataSource = DatabaseConfig.getInstance();
     this.rechnungsRepo = new RechnungsMetadatenRepository(dataSource);
-    this.positionRepo = new RechnungspositionRepository(dataSource);
+    this.positionRepo = new RechnungspositionRepository();
   }
 
   @Override
@@ -42,7 +42,6 @@ public class RechnungsmetadatenService
 
       try {
         final Rechnungsmetadaten metadaten = Rechnungsmetadaten.fromProto(request);
-
         final UUID rechnungsId = rechnungsRepo.save(connection, metadaten);
         positionRepo.saveAll(connection, metadaten.positionen(), rechnungsId);
 
@@ -52,17 +51,16 @@ public class RechnungsmetadatenService
         sendResponse(responseObserver, 200, "Erfolgreich gespeichert", rechnungsId.toString());
 
       } catch (ConstraintViolationException e) {
-        connection.rollback();
+        safeRollback(connection);
         String fehlerDetails =
             e.getConstraintViolations().stream()
                 .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
                 .collect(Collectors.joining(", "));
-
         logger.warn("Validierungsfehler: Rechnungsnummer {}: {}", rechnungsnummer, fehlerDetails);
         sendResponse(responseObserver, 400, "Validierungsfehler: " + fehlerDetails, null);
 
       } catch (Exception e) {
-        connection.rollback();
+        safeRollback(connection);
         logger.error("Interner Fehler: Rechnungsnummer: {}", rechnungsnummer, e);
         sendResponse(responseObserver, 500, "Interner Fehler: " + e.getMessage(), null);
       }
@@ -70,6 +68,16 @@ public class RechnungsmetadatenService
     } catch (SQLException e) {
       logger.error("Datenbankfehler: Rechnungsnummer {}", rechnungsnummer, e);
       sendResponse(responseObserver, 500, "Datenbankfehler", null);
+    }
+  }
+
+  private static void safeRollback(final Connection connection) {
+    try {
+      if (connection != null) {
+        connection.rollback();
+      }
+    } catch (SQLException e) {
+      logger.error("Rollback fehlgeschlagen", e);
     }
   }
 

--- a/zahlungssystem/src/main/java/com/example/zahlungsystem/ZahlungsConsumer.java
+++ b/zahlungssystem/src/main/java/com/example/zahlungsystem/ZahlungsConsumer.java
@@ -5,6 +5,7 @@ import com.example.zahlungsystem.config.DatabaseMigration;
 import com.example.zahlungsystem.entity.Zahlungsauftrag;
 import com.example.zahlungsystem.repository.ZahlungsStatusType;
 import com.example.zahlungsystem.repository.ZahlungsauftragRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.rabbitmq.client.Channel;
@@ -13,6 +14,10 @@ import com.rabbitmq.client.DeliverCallback;
 import io.github.cdimascio.dotenv.Dotenv;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,9 +30,10 @@ public class ZahlungsConsumer {
       JsonMapper.builder().addModule(new JavaTimeModule()).build();
 
   private final ZahlungsauftragRepository repository;
+  private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
   public ZahlungsConsumer() {
-    this.repository = new ZahlungsauftragRepository(DatabaseConfig.getInstance());
+    this.repository = new ZahlungsauftragRepository();
   }
 
   public void start() throws IOException, TimeoutException {
@@ -36,15 +42,33 @@ public class ZahlungsConsumer {
     factory.setPort(Integer.parseInt(dotenv.get("RABBITMQ_PORT")));
     factory.setUsername(dotenv.get("RABBITMQ_USERNAME"));
     factory.setPassword(dotenv.get("RABBITMQ_PASSWORD"));
-
-    factory.setThreadFactory(Thread.ofVirtual().factory());
+    factory.setAutomaticRecoveryEnabled(true);
+    factory.setTopologyRecoveryEnabled(true);
 
     try (var connection = factory.newConnection();
         var channel = connection.createChannel()) {
 
       String queue = dotenv.get("RABBITMQ_QUEUE_NAME");
-      channel.queueDeclare(queue, true, false, false, null);
-      channel.basicQos(10);
+      channel.exchangeDeclare(queue + ".dlx", "direct", true);
+      channel.queueDeclare(queue + ".dlq", true, false, false, null);
+      channel.queueBind(queue + ".dlq", queue + ".dlx", queue);
+
+      Map<String, Object> args = Map.of("x-dead-letter-exchange", queue + ".dlx");
+      try {
+        channel.queueDeclare(queue, true, false, false, args);
+      } catch (IOException e) {
+        if (e.getMessage() != null && e.getMessage().contains("inequivalent")) {
+          logger.warn(
+              "Queue '{}' existiert mit abweichenden Argumenten — lösche und erstelle neu.", queue);
+          channel.queueDelete(queue);
+          channel.queueDeclare(queue, true, false, false, args);
+        } else {
+          throw e;
+        }
+      }
+
+      // nur 1 Nachricht gleichzeitig
+      channel.basicQos(1);
 
       logger.info("ZahlungsConsumer bereit. Warte auf Nachrichten in '{}'...", queue);
 
@@ -55,63 +79,141 @@ public class ZahlungsConsumer {
           };
 
       channel.basicConsume(queue, false, deliverCallback, _ -> {});
-
-      Thread.currentThread().join();
+      shutdownLatch.await();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      logger.error("Consumer unterbrochen.");
+      logger.info("RabbitMQ-Consumer sauber beendet.");
     }
   }
 
   private void processMessage(Channel channel, long tag, String message) {
     String ref = "Unbekannt";
+    boolean dbCommitted = false;
+    boolean transientError = true;
     try {
       Zahlungsauftrag auftrag = MAPPER.readValue(message, Zahlungsauftrag.class);
       ref = auftrag.zahlungsReferenz();
 
-      try (java.sql.Connection conn = DatabaseConfig.getInstance().getConnection()) {
-        repository.save(conn, auftrag);
-        logger.info(
-            "Zahlungsauftrag in Datenbank registriert. Referenz: {}, Status: AUSSTEHEND", ref);
+      try (Connection conn = DatabaseConfig.getInstance().getConnection()) {
+        conn.setAutoCommit(false);
 
-        repository.updateStatus(conn, ref, ZahlungsStatusType.IN_BEARBEITUNG);
-        logger.info("Zahlvorgang wird eingeleitet. Referenz: {}, Status: IN_BEARBEITUNG", ref);
-
-        Thread.sleep(1000);
-
-        boolean erfolg = Math.random() > 0.1;
-
-        if (erfolg) {
-          repository.updateStatus(conn, ref, ZahlungsStatusType.ABGESCHLOSSEN);
+        var currentStatus = repository.findStatus(conn, ref);
+        if (currentStatus.isPresent() && currentStatus.get().isTerminal()) {
           logger.info(
-              "Zahlvorgang erfolgreich abgeschlossen. Referenz: {}, Status: ABGESCHLOSSEN", ref);
+              "Zahlung {} bereits abgeschlossen (Status: {}). Überspringe.",
+              ref,
+              currentStatus.get());
+          commitTransaction(conn);
+          dbCommitted = true;
         } else {
-          repository.updateStatus(conn, ref, ZahlungsStatusType.FEHLGESCHLAGEN);
-          logger.warn("Zahlvorgang abgebrochen. Referenz: {}, Status: FEHLGESCHLAGEN", ref);
-        }
+          if (currentStatus.isEmpty()) {
+            repository.save(conn, auftrag);
+            logger.info(
+                "Zahlungsauftrag in Datenbank registriert. Referenz: {}, Status: AUSSTEHEND", ref);
+          } else {
+            logger.info("Zahlung {} wiederaufgenommen (Status: {}).", ref, currentStatus.get());
+          }
 
-        channel.basicAck(tag, false);
-        logger.debug("RabbitMQ-Bestatigung gesendet für Referenz: {}", ref);
+          repository.updateStatus(conn, ref, ZahlungsStatusType.IN_BEARBEITUNG);
+          logger.info("Zahlvorgang wird eingeleitet. Referenz: {}, Status: IN_BEARBEITUNG", ref);
+
+          boolean erfolg = Math.random() > 0.1;
+          ZahlungsStatusType endStatus =
+              erfolg ? ZahlungsStatusType.ABGESCHLOSSEN : ZahlungsStatusType.FEHLGESCHLAGEN;
+
+          repository.updateStatus(conn, ref, endStatus);
+          if (erfolg) {
+            logger.info(
+                "Zahlvorgang erfolgreich abgeschlossen. Referenz: {}, Status: ABGESCHLOSSEN", ref);
+          } else {
+            logger.warn("Zahlvorgang abgebrochen. Referenz: {}, Status: FEHLGESCHLAGEN", ref);
+          }
+
+          commitTransaction(conn);
+          dbCommitted = true;
+        }
       }
+    } catch (SQLException e) {
+      logger.error("Datenbankfehler bei Referenz {}: {}", ref, e.toString());
+    } catch (JsonProcessingException | IllegalArgumentException e) {
+      transientError = false;
+      logger.error("Fehlerhafte Nachricht, wird verworfen: {}", e.toString());
     } catch (Exception e) {
-      logger.error("Fehler bei der Verarbeitung der Referenz {}: {}", ref, e.getMessage());
-      try {
-        channel.basicNack(tag, false, true);
-        logger.info("Zahlung {} aufgrund eines technischen Fehlers zurückgestellt.", ref);
-      } catch (Exception nackEx) {
-        logger.error("Nack konnte nicht gesendet werden: {}", nackEx.getMessage());
-      }
+      logger.error("Transienter Fehler bei Referenz {}: {}", ref, e.toString());
+    }
+
+    if (dbCommitted) {
+      safeAck(channel, tag, ref);
+    } else if (!transientError) {
+      safeReject(channel, tag, ref);
+    } else {
+      safeNack(channel, tag, ref);
     }
   }
 
-  public static void main(String[] args) {
+  private static void commitTransaction(Connection conn) throws SQLException {
+    try {
+      conn.commit();
+    } catch (SQLException e) {
+      try {
+        conn.rollback();
+      } catch (SQLException rollbackEx) {
+        logger.error("Rollback fehlgeschlagen: {}", rollbackEx.getMessage());
+      }
+      throw e;
+    }
+  }
+
+  private void safeAck(Channel channel, long tag, String ref) {
+    try {
+      channel.basicAck(tag, false);
+      logger.debug("ACK gesendet für Referenz: {}", ref);
+    } catch (Exception e) {
+      logger.error(
+          "ACK fehlgeschlagen für Referenz {} — DB ist committed, "
+              + "Redelivery wird durch Idempotenz abgefangen.",
+          ref,
+          e);
+    }
+  }
+
+  private void safeNack(Channel channel, long tag, String ref) {
+    try {
+      channel.basicNack(tag, false, true);
+      logger.info("NACK gesendet — Zahlung {} wird zurückgestellt.", ref);
+    } catch (Exception e) {
+      logger.error("NACK fehlgeschlagen für Referenz {}: {}", ref, e.getMessage());
+    }
+  }
+
+  private void safeReject(Channel channel, long tag, String ref) {
+    try {
+      channel.basicReject(tag, false);
+      logger.warn("REJECT gesendet — Zahlung {} in Dead Letter Queue verschoben.", ref);
+    } catch (Exception e) {
+      logger.error("Reject fehlgeschlagen für Referenz {}: {}", ref, e.getMessage());
+    }
+  }
+
+  public void shutdown() {
+    logger.info("Shutdown-Signal empfangen.");
+    shutdownLatch.countDown();
+  }
+
+  static void main() {
     try {
       DatabaseMigration.migrate();
 
-      new ZahlungsConsumer().start();
+      ZahlungsConsumer consumer = new ZahlungsConsumer();
+      Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(consumer::shutdown));
+
+      consumer.start();
     } catch (Exception e) {
-      logger.error("Systemfehler: {}", e.getMessage());
+      logger.error("Systemfehler: {} — {}", e.getClass().getSimpleName(), e.getMessage());
       System.exit(1);
+    } finally {
+      logger.info("Schließe Datenbankverbindungspool...");
+      DatabaseConfig.shutdown();
     }
   }
 }

--- a/zahlungssystem/src/main/java/com/example/zahlungsystem/config/DatabaseConfig.java
+++ b/zahlungssystem/src/main/java/com/example/zahlungsystem/config/DatabaseConfig.java
@@ -16,11 +16,18 @@ public class DatabaseConfig {
     config.setUsername(dotenv.get("ZAHLUNGSSYSTEM_DB_USERNAME"));
     config.setPassword(dotenv.get("ZAHLUNGSSYSTEM_DB_PASSWORD"));
     config.setMaximumPoolSize(10);
+    config.setLeakDetectionThreshold(10_000);
 
     dataSource = new HikariDataSource(config);
   }
 
   public static DataSource getInstance() {
     return dataSource;
+  }
+
+  public static void shutdown() {
+    if (dataSource != null && !dataSource.isClosed()) {
+      dataSource.close();
+    }
   }
 }

--- a/zahlungssystem/src/main/java/com/example/zahlungsystem/repository/ZahlungsStatusType.java
+++ b/zahlungssystem/src/main/java/com/example/zahlungsystem/repository/ZahlungsStatusType.java
@@ -4,5 +4,9 @@ public enum ZahlungsStatusType {
   AUSSTEHEND,
   IN_BEARBEITUNG,
   ABGESCHLOSSEN,
-  FEHLGESCHLAGEN
+  FEHLGESCHLAGEN;
+
+  public boolean isTerminal() {
+    return this == ABGESCHLOSSEN || this == FEHLGESCHLAGEN;
+  }
 }

--- a/zahlungssystem/src/main/java/com/example/zahlungsystem/repository/ZahlungsauftragRepository.java
+++ b/zahlungssystem/src/main/java/com/example/zahlungsystem/repository/ZahlungsauftragRepository.java
@@ -2,7 +2,6 @@ package com.example.zahlungsystem.repository;
 
 import com.example.zahlungsystem.entity.Zahlungsauftrag;
 import java.sql.*;
-import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,16 +15,16 @@ public class ZahlungsauftragRepository {
         INSERT INTO zahlungsauftraege (
             zahlungs_referenz, betrag, iban, faelligkeitsdatum, status
         ) VALUES (?, ?, ?, ?, ?::zahlungs_status_type)
+        ON CONFLICT (zahlungs_referenz) DO NOTHING
         """;
+
+  private static final String SELECT_STATUS_SQL =
+      "SELECT status FROM zahlungsauftraege WHERE zahlungs_referenz = ?";
 
   private static final String UPDATE_STATUS_SQL =
       "UPDATE zahlungsauftraege SET status = ?::zahlungs_status_type WHERE zahlungs_referenz = ?";
 
-  private final DataSource dataSource;
-
-  public ZahlungsauftragRepository(final DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  public ZahlungsauftragRepository() {}
 
   /// Speichert einen neuen Zahlungsauftrag.
   ///
@@ -48,13 +47,27 @@ public class ZahlungsauftragRepository {
 
       int affectedRows = stmt.executeUpdate();
       if (affectedRows == 0) {
-        throw new SQLException("Speichern des Zahlungsauftrags fehlgeschlagen.");
+        logger.info(
+            "Zahlungsauftrag bereits vorhanden (Redelivery): {}", auftrag.zahlungsReferenz());
+      } else {
+        logger.info("Zahlungsauftrag erfolgreich gespeichert: {}", auftrag.zahlungsReferenz());
       }
-
-      logger.info("Zahlungsauftrag erfolgreich gespeichert: {}", auftrag.zahlungsReferenz());
     } catch (SQLException e) {
       logger.error("Fehler beim Insert des Zahlungsauftrags: {}", e.getMessage());
       throw e;
+    }
+  }
+
+  public java.util.Optional<ZahlungsStatusType> findStatus(final Connection conn, final String ref)
+      throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement(SELECT_STATUS_SQL)) {
+      stmt.setString(1, ref);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          return java.util.Optional.of(ZahlungsStatusType.valueOf(rs.getString("status")));
+        }
+        return java.util.Optional.empty();
+      }
     }
   }
 


### PR DESCRIPTION
Offene SQL Connections durch try-with-resources in RechnungsmetadatenService und ZahlungsConsumer geschlossen.

ACK nur nach erfolgreichem DB-Commit, NACK mit Requeue bei transienten Fehlern.

Hinzufügen von Dead Letter Queue.