### PR TITLE
Anpassen des MetadatenSpeichernHandler damit Camunda mitbekommt, dass…

### DIFF
--- a/camunda-workers/src/main/java/com/example/camundaworkers/MetadatenSpeichernHandler.java
+++ b/camunda-workers/src/main/java/com/example/camundaworkers/MetadatenSpeichernHandler.java
@@ -73,8 +73,8 @@ public class MetadatenSpeichernHandler implements JobHandler {
         logger.warn(
             "gRPC-Fehler: {} - {}", response.getResponseCode(), response.getResponsemessage());
         client
-            .newFailCommand(job.getKey())
-            .retries(0)
+            .newThrowErrorCommand(job.getKey())
+            .errorCode(String.valueOf(response.getResponseCode()))
             .errorMessage("gRPC-Fehler: " + response.getResponsemessage())
             .send()
             .join();


### PR DESCRIPTION
… es einen Fehler im gRPC-Service gibt